### PR TITLE
Fixed problem with the finding of the .git directory

### DIFF
--- a/src/lein_sha_version/plugin.clj
+++ b/src/lein_sha_version/plugin.clj
@@ -8,9 +8,8 @@
 (defn git-sha [{:keys [root version sha]}]
   (println "Finding SHA for" root)
   (let [^Repository repository (.. (FileRepositoryBuilder.)
-                                   (setGitDir (file root ".git"))
                                    (readEnvironment)
-                                   (findGitDir)
+                                   (findGitDir (file root))
                                    (build))
         ^ObjectId head (.resolve repository "HEAD")]
     (if head


### PR DESCRIPTION
setGitDir seemed to stop the searching up the tree for the .git
directory. findGitDir can take an argument of where to start the
search.
